### PR TITLE
Reduce building time by only building the keycloak-server

### DIFF
--- a/cico_setup.sh
+++ b/cico_setup.sh
@@ -45,7 +45,10 @@ function install_deps() {
 }
 
 function build() {
-  mvn clean install -DskipTests=true -Pdistribution
+  # Set the version according to the ENV variable
+  mvn -q versions:set -DgenerateBackupPoms=false -DnewVersion=$KEYCLOAK_VERSION
+  # Only build the keycloak-server to save time
+  mvn clean install -DskipTests=true -pl :keycloak-server-dist -am -P distribution
 }
 
 function deploy() {

--- a/cico_setup.sh
+++ b/cico_setup.sh
@@ -59,8 +59,8 @@ function deploy() {
 
   rm docker/keycloak-$KEYCLOAK_VERSION.tar.gz
 
-  docker tag $DOCKER_IMAGE_DEPLOY 8.43.84.245.xip.io/$REPO_NAME/$PROJECT_NAME-postgres:latest
-  docker push 8.43.84.245.xip.io/$REPO_NAME/$PROJECT_NAME-postgres:latest
+  docker tag $DOCKER_IMAGE_DEPLOY registry.devshift.net/$REPO_NAME/$PROJECT_NAME-postgres:latest
+  docker push registry.devshift.net/$REPO_NAME/$PROJECT_NAME-postgres:latest
   echo 'CICO: Image pushed, ready to update deployed app'
 }
 


### PR DESCRIPTION
We save time by only building the `keycloak-server` distribution