### PR TITLE
Identity broker service may fail to validate client session if there is more then one active session

### DIFF
--- a/services/src/main/java/org/keycloak/services/resources/IdentityBrokerService.java
+++ b/services/src/main/java/org/keycloak/services/resources/IdentityBrokerService.java
@@ -255,8 +255,8 @@ public class IdentityBrokerService implements IdentityProvider.AuthenticationCal
                 byte[] check = md.digest(input.getBytes(StandardCharsets.UTF_8));
                 if (MessageDigest.isEqual(decoded, check)) {
                     clientSession = cs;
+                    break;
                 }
-                break;
             }
         }
         if (clientSession == null) {


### PR DESCRIPTION
Also submitted a PR to fix upstream - https://github.com/keycloak/keycloak/pull/3939

@hectorj2f  please merge before the next KC rebuilding ;)