### PR TITLE
Configure the debug level by using an ENV variable

### DIFF
--- a/docker/standalone.xml
+++ b/docker/standalone.xml
@@ -45,7 +45,7 @@
                     <properties path="application-roles.properties" relative-to="jboss.server.config.dir"/>
                 </authorization>
             </security-realm>
-            <!-- Added by Almighty keycloak team -->
+            <!-- Added by openshift.io keycloak team -->
             <security-realm name="UndertowRealm">
                 <server-identities>
                     <ssl>
@@ -86,7 +86,7 @@
     <profile>
         <subsystem xmlns="urn:jboss:domain:logging:3.0">
             <console-handler name="CONSOLE">
-                <!-- Modified by Almighty keycloak team -->
+                <!-- Modified by openshift.io keycloak team -->
                 <level name="${env.KEYCLOAK_LOGLEVEL:INFO}"/>
                 <!--   xxxxxxxxxxxxxxxxxxxxxxxxx   -->
                 <formatter>
@@ -110,13 +110,13 @@
             <logger category="sun.rmi">
                 <level name="WARN"/>
             </logger>
-            <!-- Added by Almighty keycloak team -->
+            <!-- Added by openshift.io keycloak team -->
             <logger category="org.hibernate">
                 <level name="INFO"/>
             </logger>
             <!--   xxxxxxxxxxxxxxxxxxxxxxxxx   -->
             <root-logger>
-                <!-- Modified by Almighty keycloak team -->
+                <!-- Modified by openshift.io keycloak team -->
                 <level name="${env.KEYCLOAK_LOGLEVEL:INFO}"/>
                 <!--   xxxxxxxxxxxxxxxxxxxxxxxxx   -->
                 <handlers>
@@ -382,7 +382,7 @@
                     <filter-ref name="server-header"/>
                     <filter-ref name="x-powered-by-header"/>
                 </host>
-                <!-- Added by Almighty keycloak team -->
+                <!-- Added by openshift.io keycloak team -->
                 <https-listener name="https" socket-binding="https" security-realm="UndertowRealm"/>
                 <!--   xxxxxxxxxxxxxxxxxxxxxxxxx   -->
             </server>

--- a/docker/standalone.xml
+++ b/docker/standalone.xml
@@ -53,6 +53,7 @@
                     </ssl>
                 </server-identities>
             </security-realm>
+            <!--   xxxxxxxxxxxxxxxxxxxxxxxxx   -->
         </security-realms>
         <audit-log>
             <formatters>
@@ -85,7 +86,9 @@
     <profile>
         <subsystem xmlns="urn:jboss:domain:logging:3.0">
             <console-handler name="CONSOLE">
-                <level name="INFO"/>
+                <!-- Modified by Almighty keycloak team -->
+                <level name="${env.KEYCLOAK_LOGLEVEL:INFO}"/>
+                <!--   xxxxxxxxxxxxxxxxxxxxxxxxx   -->
                 <formatter>
                     <named-formatter name="COLOR-PATTERN"/>
                 </formatter>
@@ -107,8 +110,15 @@
             <logger category="sun.rmi">
                 <level name="WARN"/>
             </logger>
-            <root-logger>
+            <!-- Added by Almighty keycloak team -->
+            <logger category="org.hibernate">
                 <level name="INFO"/>
+            </logger>
+            <!--   xxxxxxxxxxxxxxxxxxxxxxxxx   -->
+            <root-logger>
+                <!-- Modified by Almighty keycloak team -->
+                <level name="${env.KEYCLOAK_LOGLEVEL:INFO}"/>
+                <!--   xxxxxxxxxxxxxxxxxxxxxxxxx   -->
                 <handlers>
                     <handler name="CONSOLE"/>
                     <handler name="FILE"/>
@@ -374,6 +384,7 @@
                 </host>
                 <!-- Added by Almighty keycloak team -->
                 <https-listener name="https" socket-binding="https" security-realm="UndertowRealm"/>
+                <!--   xxxxxxxxxxxxxxxxxxxxxxxxx   -->
             </server>
             <servlet-container name="default">
                 <jsp-config/>


### PR DESCRIPTION
By using an ENV variable, we can now better control the debug level of KC.

`-e KEYCLOAK_LOGLEVEL=DEBUG`
