### PR TITLE
Add parameters to reach other KC peers

### DIFF
--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -8,6 +8,10 @@ if [[ -z "${KEYCLOAK_SERVER_DOMAIN}" ]]; then
   KEYCLOAK_SERVER_DOMAIN="localhost"
 fi
 
+if [[ -z "${INTERNAL_POD_IP}" ]]; then
+  INTERNAL_POD_IP="127.0.0.1"
+fi
+
 echo "Create keycloak store"
 keytool -genkey -alias ${KEYCLOAK_SERVER_DOMAIN} -keyalg RSA -keystore keycloak.jks -validity 10950 -keypass $KEYSTORE_PASSWORD -storepass $KEYSTORE_PASSWORD << ANSWERS
 ${KEYCLOAK_SERVER_DOMAIN}
@@ -38,7 +42,7 @@ fi
 
 if [[ "${OPERATING_MODE}" == "clustered" ]]; then
   echo "Starting keycloak-server on clustered mode..."
-  exec /opt/jboss/keycloak/bin/standalone.sh --server-config=standalone-ha.xml $@
+  exec /opt/jboss/keycloak/bin/standalone.sh --server-config=standalone-ha.xml -bmanagement=$INTERNAL_POD_IP -bprivate=$INTERNAL_POD_IP -u 230.0.0.4 $@
 else
   echo "Starting keycloak-server on standalone mode..."
   exec /opt/jboss/keycloak/bin/standalone.sh $@

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -1,16 +1,9 @@
 #!/bin/bash
 
-if [[ -z "${KEYSTORE_PASSWORD}" ]]; then
-  KEYSTORE_PASSWORD="almighty"
-fi
 
-if [[ -z "${KEYCLOAK_SERVER_DOMAIN}" ]]; then
-  KEYCLOAK_SERVER_DOMAIN="localhost"
-fi
-
-if [[ -z "${INTERNAL_POD_IP}" ]]; then
-  INTERNAL_POD_IP="127.0.0.1"
-fi
+KEYSTORE_PASSWORD=${KEYSTORE_PASSWORD:-"almighty"}
+KEYCLOAK_SERVER_DOMAIN=${KEYCLOAK_SERVER_DOMAIN:-"localhost"}
+INTERNAL_POD_IP=${INTERNAL_POD_IP:-"127.0.0.1"}
 
 echo "Create keycloak store"
 keytool -genkey -alias ${KEYCLOAK_SERVER_DOMAIN} -keyalg RSA -keystore keycloak.jks -validity 10950 -keypass $KEYSTORE_PASSWORD -storepass $KEYSTORE_PASSWORD << ANSWERS

--- a/minishift/keycloak.json
+++ b/minishift/keycloak.json
@@ -56,6 +56,14 @@
                 ],
                 "env":[
                   {
+                    "name":"INTERNAL_POD_IP",
+                    "valueFrom": {
+                       "fieldRef": {
+                          "fieldPath": "status.podIP"
+                       }
+                    }
+                  },
+                  {
                     "name":"KEYCLOAK_USER",
                     "value":"admin"
                   },

--- a/openshift/keycloak.app.yaml
+++ b/openshift/keycloak.app.yaml
@@ -55,6 +55,10 @@ objects:
             initialDelaySeconds: 60
           terminationMessagePath: /dev/termination-log
           env:
+          - name: INTERNAL_POD_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
           - name: KEYCLOAK_USER
             valueFrom:
               secretKeyRef:


### PR DESCRIPTION
I added a multicast IP and set internal pod ip to make reachable the pods between themselves.
<img width="890" alt="screen shot 2017-04-05 at 2 06 58 pm" src="https://cloud.githubusercontent.com/assets/3602792/24704741/2c5a58c4-1a09-11e7-997d-c2a1990f5369.png">


<img width="910" alt="screen shot 2017-04-05 at 2 06 20 pm" src="https://cloud.githubusercontent.com/assets/3602792/24704704/10f24d30-1a09-11e7-9d67-7369060f1b60.png">

@alexeykazakov It might be a bit hard to validate the login, but I am open to suggestions on how to validate it in my local KC cluster
