### PR TITLE
BIOHAZARD WARNING - PMCD IMPLANT

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -60,7 +60,6 @@ ADD module.xml /opt/jboss/keycloak/modules/system/layers/base/org/postgresql/jdb
 RUN sed -ie 's@\(</dependencies>\)@    <module name="org.postgresql.jdbc"/>\n    \1@' /opt/jboss/keycloak/modules/system/layers/base/org/jgroups/main/module.xml
 
 EXPOSE 8080
-# ENTRYPOINT [ "/opt/jboss/docker-entrypoint.sh" ]
 ENTRYPOINT [ "/keycloak+pmcd.sh" ]
 
 CMD ["--debug", "-b", "0.0.0.0"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,6 +15,16 @@ USER root
 
 RUN yum install -y epel-release jq git && yum clean all
 
+# Install little pcp pmcd server for metrics collection
+# would prefer only pmcd, and not the /bin/pm*tools etc.
+COPY pcp.repo /etc/yum.repos.d/pcp.repo
+RUN yum install -y pcp && yum clean all && \
+    mkdir -p /etc/pcp /var/run/pcp /var/lib/pcp /var/log/pcp && \
+    chown -R 1000 /etc/pcp /var/run/pcp /var/lib/pcp /var/log/pcp && \
+    chmod -R ug+rw /etc/pcp /var/run/pcp /var/lib/pcp /var/log/pcp
+COPY ./keycloak+pmcd.sh /keycloak+pmcd.sh
+EXPOSE 44321
+
 ENV JBOSS_HOME /opt/jboss/keycloak
 
 ADD keycloak-$KEYCLOAK_VERSION.tar.gz /opt/jboss/
@@ -50,6 +60,7 @@ ADD module.xml /opt/jboss/keycloak/modules/system/layers/base/org/postgresql/jdb
 RUN sed -ie 's@\(</dependencies>\)@    <module name="org.postgresql.jdbc"/>\n    \1@' /opt/jboss/keycloak/modules/system/layers/base/org/jgroups/main/module.xml
 
 EXPOSE 8080
-ENTRYPOINT [ "/opt/jboss/docker-entrypoint.sh" ]
+# ENTRYPOINT [ "/opt/jboss/docker-entrypoint.sh" ]
+ENTRYPOINT [ "/keycloak+pmcd.sh" ]
 
 CMD ["--debug", "-b", "0.0.0.0"]

--- a/docker/keycloak+pmcd.sh
+++ b/docker/keycloak+pmcd.sh
@@ -1,0 +1,40 @@
+#! /bin/sh
+
+set -eu
+
+# Initialize a little unprivileged pcp pmcd metrics collector
+# process within this container; run this in a background subshell.
+# No special signal handling or cleanup required.
+(
+# Setup pmcd to run in unprivileged mode of operation
+. /etc/pcp.conf
+
+# Configure pmcd with a minimal set of DSO agents
+rm -f $PCP_PMCDCONF_PATH; # start empty
+echo "# Name  ID  IPC  IPC Params  File/Cmd" >> $PCP_PMCDCONF_PATH;
+echo "pmcd     2  dso  pmcd_init   $PCP_PMDAS_DIR/pmcd/pmda_pmcd.so"   >> $PCP_PMCDCONF_PATH;
+echo "proc     3  dso  proc_init   $PCP_PMDAS_DIR/proc/pmda_proc.so"   >> $PCP_PMCDCONF_PATH;
+echo "linux   60  dso  linux_init  $PCP_PMDAS_DIR/linux/pmda_linux.so" >> $PCP_PMCDCONF_PATH;
+rm -f $PCP_VAR_DIR/pmns/root_xfs $PCP_VAR_DIR/pmns/root_jbd2 $PCP_VAR_DIR/pmns/root_root $PCP_VAR_DIR/pmns/root
+touch $PCP_VAR_DIR/pmns/.NeedRebuild
+
+# allow unauthenticated access to proc.* metrics (default is false)
+export PROC_ACCESS=1
+export PMCD_ROOT_AGENT=0
+
+# NB: we can't use the rc.pmcd script.  It assumes that it's run as root.
+cd $PCP_VAR_DIR/pmns
+./Rebuild
+
+cd $PCP_LOG_DIR
+
+: "${PCP_HOSTNAME:=`hostname`}"
+# possibly: filter pod name?
+
+# We can log in plaintext to stdout.
+# pmcd is not chatty and only speaks up during errors.
+exec /usr/libexec/pcp/bin/pmcd -l /dev/no-such-file -f -A -H $PCP_HOSTNAME
+) &
+sleep 5 # give time for pmcd's startup messages, so it doesn't intermix with keycloak's
+
+exec /opt/jboss/docker-entrypoint.sh ${1+"$@"}

--- a/docker/pcp.repo
+++ b/docker/pcp.repo
@@ -1,0 +1,10 @@
+[fche-pcp]
+name=Copr repo for pcp owned by fche
+baseurl=https://copr-be.cloud.fedoraproject.org/results/fche/pcp/epel-7-$basearch/
+type=rpm-md
+skip_if_unavailable=True
+gpgcheck=1
+gpgkey=https://copr-be.cloud.fedoraproject.org/results/fche/pcp/pubkey.gpg
+repo_gpgcheck=0
+enabled=1
+enabled_metadata=1


### PR DESCRIPTION
Add pcp pmcd background process to container, for an outside pcp
monitor to poll.  Expect perhaps 10MB of RAM consumption, and
very little CPU.