### PR TITLE
Reduces size of docker image by cleaning kc dirs

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -28,7 +28,7 @@ EXPOSE 44321
 ENV JBOSS_HOME /opt/jboss/keycloak
 
 ADD keycloak-$KEYCLOAK_VERSION.tar.gz /opt/jboss/
-RUN mkdir -p $JBOSS_HOME && cd /opt/jboss/keycloak-$KEYCLOAK_VERSION && cp -R * $JBOSS_HOME
+RUN mv /opt/jboss/keycloak-$KEYCLOAK_VERSION $JBOSS_HOME
 
 WORKDIR $JBOSS_HOME
 


### PR DESCRIPTION
Moves extracted KC folder instead of copying. Previously we forgot to delete `-version` folder resulting in 200MB extra size of the image