### PR TITLE
Added flag to extract the Java GC current configuration

### DIFF
--- a/openshift/keycloak.app.yaml
+++ b/openshift/keycloak.app.yaml
@@ -110,6 +110,7 @@ objects:
               -XX:MinHeapFreeRatio=20
               -XX:MaxHeapFreeRatio=40
               -XX:GCTimeRatio=4
+              -XX:+PrintGCDetails
               -XX:AdaptiveSizePolicyWeight=90
               -XX:MaxMetaspaceSize=512m -Djava.net.preferIPv4Stack=true
               -Djboss.modules.system.pkgs=org.jboss.byteman


### PR DESCRIPTION
As discussed, it'd be good to prompt the current GC configuration in our logs